### PR TITLE
Fix error overlay persistence

### DIFF
--- a/calqula/src/client/components/GraphContainer.vue
+++ b/calqula/src/client/components/GraphContainer.vue
@@ -438,6 +438,7 @@ function validateData(data: unknown): asserts data is Config {
 }
 
 function initialize(): void {
+  errorMessage.value = '';
   try {
     validateData(props.config);
     // View


### PR DESCRIPTION
## Summary
- reset `errorMessage` before attempting to initialize graphs

## Testing
- `npx prettier --write calqula/src/client/components/GraphContainer.vue`
- `pnpm -r exec tsc -p calqula/tsconfig.json --noEmit` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68440bf4e3688326b70eae1a481a4d94